### PR TITLE
♻️ Add .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+format_code_in_doc_comments = true
+format_macro_matchers = true

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -3,19 +3,18 @@
 //! # Examples
 //!
 //! ```
-//! use cubby_connect_server::config::{Config, AuthServer};
+//! use cubby_connect_server::config::{AuthServer, Config};
 //!
 //! // using only default values
 //! let config = Config::builder().build().unwrap();
 //!
 //! // changing values
 //! let config = Config::builder()
-//!        .auth_config(AuthServer::builder().password("password").build().unwrap())
-//!        .verbose(3)
-//!        .build()
-//!        .unwrap();
+//!     .auth_config(AuthServer::builder().password("password").build().unwrap())
+//!     .verbose(3)
+//!     .build()
+//!     .unwrap();
 //! ```
-//!
 
 #[cfg(feature = "serial")]
 use serde::{Deserialize, Serialize};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -13,7 +13,6 @@
 //! - connection to credential server for authentication
 //! - version matching for compatability
 //! - beautiful logging support
-//!
 
 #[macro_use]
 extern crate derive_builder;

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -6,12 +6,12 @@
 //! # Examples
 //!
 //! ```
+//! use cubby_connect_server::pipe::{Pipe, PipeFactory};
+//! use futures::future::{ok, LocalBoxFuture, Ready};
 //! use std::fmt::Display;
 //! use std::future::Future;
 //! use std::marker::PhantomData;
 //! use std::task::{Context, Poll};
-//! use futures::future::{ok, Ready, LocalBoxFuture};
-//! use cubby_connect_server::pipe::{Pipe, PipeFactory};
 //!
 //! // Factory of Echo.
 //! pub struct EchoFactory;
@@ -19,7 +19,7 @@
 //! // Pipe that sends the message to next as is
 //! pub struct Echo<T, P>
 //! where
-//!     P: Pipe<T>
+//!     P: Pipe<T>,
 //! {
 //!     prev: P,
 //!     _marker: PhantomData<T>,
@@ -39,7 +39,7 @@
 //!     fn new_pipe(&self, prev: P) -> Self::Future {
 //!         ok(Echo {
 //!             prev,
-//!             _marker: PhantomData::default()
+//!             _marker: PhantomData::default(),
 //!         })
 //!     }
 //! }
@@ -69,7 +69,7 @@
 //!
 //! impl<S> Pipe<S> for Print
 //! where
-//!     S: Display
+//!     S: Display,
 //! {
 //!     type Error = ();
 //!     type Future = Ready<Result<(), Self::Error>>;
@@ -95,7 +95,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
 
 use std::future::Future;
 


### PR DESCRIPTION
- format based on configuration
- from now on, formatter would format documentation as well