### PR TITLE
Add handler & layer related traits & structs

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,3 +34,6 @@ serial = ["serde"]
 
 [build-dependencies]
 prost-build = "0.8"
+
+[dev-dependencies]
+num-traits = "0.2.14"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,7 +26,7 @@ derive_builder = "0.10.2"
 futures = "0.3.17"
 prost = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
-tokio = { version = "1.10.1", features = ["net", "rt-multi-thread", "macros"] }
+tokio = { version = "1.10.1", features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = []

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -16,9 +16,10 @@
 //!     .unwrap();
 //! ```
 
+use std::path::PathBuf;
+
 #[cfg(feature = "serial")]
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 /// configuration for auth server connection
 #[cfg_attr(not(feature = "serial"), derive(Builder, Clone, Debug, Eq, PartialEq))]

--- a/server/src/fn_handler.rs
+++ b/server/src/fn_handler.rs
@@ -26,20 +26,20 @@ use std::marker::PhantomData;
 
 use crate::handler::{Handler, IntoHandler};
 
-/// `Pipe` for closures/functions for simple definition of use.
+/// `Handler` for closures/functions for simple definition of use.
 /// The type of function would be as: `async fn<T>(T) -> Result<(), Err>`
-pub struct FnHandler<F, M, Fut, Err>
+pub struct FnHandler<F, T, Fut, Err>
 where
-    F: Fn(M) -> Fut,
+    F: Fn(T) -> Fut,
     Fut: Future<Output = Result<(), Err>>,
 {
     f: F,
-    _marker: PhantomData<fn(M)>,
+    _marker: PhantomData<fn(T)>,
 }
 
-impl<F, M, Fut, Err> FnHandler<F, M, Fut, Err>
+impl<F, T, Fut, Err> FnHandler<F, T, Fut, Err>
 where
-    F: Fn(M) -> Fut,
+    F: Fn(T) -> Fut,
     Fut: Future<Output = Result<(), Err>>,
 {
     fn new(f: F) -> Self {
@@ -51,34 +51,34 @@ where
 }
 
 /// This would simply call the function
-impl<F, M, Fut, Err> Handler<M> for FnHandler<F, M, Fut, Err>
+impl<F, T, Fut, Err> Handler<T> for FnHandler<F, T, Fut, Err>
 where
-    F: Fn(M) -> Fut,
+    F: Fn(T) -> Fut,
     Fut: Future<Output = Result<(), Err>>,
 {
     type Error = Err;
     type Future = Fut;
 
-    fn call(&self, msg: M) -> Self::Future {
+    fn call(&self, msg: T) -> Self::Future {
         (self.f)(msg)
     }
 }
 
-impl<F, M, Fut, Err> IntoHandler<FnHandler<F, M, Fut, Err>, M> for F
+impl<F, T, Fut, Err> IntoHandler<FnHandler<F, T, Fut, Err>, T> for F
 where
-    F: Fn(M) -> Fut,
+    F: Fn(T) -> Fut,
     Fut: Future<Output = Result<(), Err>>,
 {
-    fn into_handler(self) -> FnHandler<F, M, Fut, Err> {
+    fn into_handler(self) -> FnHandler<F, T, Fut, Err> {
         FnHandler::new(self)
     }
 }
 
 /// public function wrapper of `FnPipe`
 /// use this to change function into `Pipe`
-pub fn fn_handler<F, M, Fut, Err>(f: F) -> FnHandler<F, M, Fut, Err>
+pub fn fn_handler<F, T, Fut, Err>(f: F) -> FnHandler<F, T, Fut, Err>
 where
-    F: Fn(M) -> Fut,
+    F: Fn(T) -> Fut,
     Fut: Future<Output = Result<(), Err>>,
 {
     FnHandler::new(f)

--- a/server/src/fn_handler.rs
+++ b/server/src/fn_handler.rs
@@ -1,0 +1,108 @@
+//! Function adapter for `Handler`
+//!
+//! # Examples
+//!
+//! ```
+//! use cubby_connect_server::fn_handler::fn_handler;
+//! use cubby_connect_server::handler::Handler;
+//! use std::fmt::Display;
+//!
+//! async fn hello<S: Display>(s: S) -> Result<(), ()> {
+//!     println!("Hello {}", s);
+//!     Ok(())
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), ()> {
+//! let handler = fn_handler(hello);
+//! // it would print "Hello World"
+//! handler.call("World");
+//! # Ok(())
+//! # }
+//! ```
+
+use std::future::Future;
+use std::marker::PhantomData;
+
+use crate::handler::{Handler, IntoHandler};
+
+/// `Pipe` for closures/functions for simple definition of use.
+/// The type of function would be as: `async fn<T>(T) -> Result<(), Err>`
+pub struct FnHandler<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    f: F,
+    _marker: PhantomData<fn(M)>,
+}
+
+impl<F, M, Fut, Err> FnHandler<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    fn new(f: F) -> Self {
+        Self {
+            f,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// This would simply call the function
+impl<F, M, Fut, Err> Handler<M> for FnHandler<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    type Error = Err;
+    type Future = Fut;
+
+    fn call(&self, msg: M) -> Self::Future {
+        (self.f)(msg)
+    }
+}
+
+impl<F, M, Fut, Err> IntoHandler<FnHandler<F, M, Fut, Err>, M> for F
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    fn into_handler(self) -> FnHandler<F, M, Fut, Err> {
+        FnHandler::new(self)
+    }
+}
+
+/// public function wrapper of `FnPipe`
+/// use this to change function into `Pipe`
+pub fn fn_handler<F, M, Fut, Err>(f: F) -> FnHandler<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    FnHandler::new(f)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn fn_handler_test() -> Result<(), ()> {
+        async fn hello<S: AsRef<str>>(name: S) -> Result<(), ()> {
+            let name = name.as_ref();
+            if name == "None" {
+                Err(())
+            } else {
+                println!("Hello, {}", name);
+                Ok(())
+            }
+        }
+
+        fn_handler(hello).call("World").await?;
+        assert!(fn_handler(hello).call("None").await.is_err());
+
+        Ok(())
+    }
+}

--- a/server/src/fn_layer.rs
+++ b/server/src/fn_layer.rs
@@ -3,6 +3,7 @@
 //! # Examples
 //!
 //! ```
+//! use cubby_connect_server::apply;
 //! use cubby_connect_server::fn_handler::fn_handler;
 //! use cubby_connect_server::fn_layer::fn_layer;
 //! use cubby_connect_server::handler::{self, Handler};

--- a/server/src/fn_pipe.rs
+++ b/server/src/fn_pipe.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! use cubby_connect_server::fn_pipe::{fn_pipe, fn_pipe_factory};
-//! use cubby_connect_server::pipe::{Pipe, PipeFactory};
+//! use cubby_connect_server::pipe::{Pipe, PipeFactory, connect};
 //! use std::fmt::Display;
 //!
 //! async fn echo<T>(t: T) -> Result<T, ()> {
@@ -24,6 +24,11 @@
 //! // `e` would be the pipe: `Echo` > `Print`
 //! let e = ef.new_pipe(p).await?;
 //! // this would print "Hello, World" to stdout
+//! e.call("Hello, World!").await?;
+//!
+//! // or
+//!
+//! let e = connect(fn_pipe_factory(echo), fn_pipe(print)).await?;
 //! e.call("Hello, World!").await?;
 //! # Ok(())
 //! # }

--- a/server/src/fn_pipe.rs
+++ b/server/src/fn_pipe.rs
@@ -4,8 +4,8 @@
 //!
 //! ```
 //! use cubby_connect_server::fn_pipe::{fn_pipe, fn_pipe_factory};
-//! use cubby_connect_server::pipe::{connect, Pipe, PipeFactory};
 //! use cubby_connect_server::pipe;
+//! use cubby_connect_server::pipe::{connect, Pipe, PipeFactory};
 //! use std::fmt::Display;
 //!
 //! async fn echo<T>(t: T) -> Result<T, ()> {

--- a/server/src/fn_pipe.rs
+++ b/server/src/fn_pipe.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! use cubby_connect_server::fn_pipe::{fn_pipe, fn_pipe_factory};
-//! use cubby_connect_server::pipe::{Pipe, PipeFactory, connect};
+//! use cubby_connect_server::pipe::{connect, Pipe, PipeFactory};
 //! use std::fmt::Display;
 //!
 //! async fn echo<T>(t: T) -> Result<T, ()> {
@@ -34,11 +34,13 @@
 //! # }
 //! ```
 
-use crate::pipe::{IntoPipe, IntoPipeFactory, Pipe, PipeFactory};
-use futures::future::{ok, LocalBoxFuture, Ready};
 use std::future::Future;
 use std::marker::PhantomData;
 use std::sync::Arc;
+
+use futures::future::{ok, LocalBoxFuture, Ready};
+
+use crate::pipe::{IntoPipe, IntoPipeFactory, Pipe, PipeFactory};
 
 /// `Pipe` for closures/functions for simple definition of use.
 /// The type of function would be as: `async fn<T>(T) -> Result<(), Err>`

--- a/server/src/fn_pipe.rs
+++ b/server/src/fn_pipe.rs
@@ -5,6 +5,7 @@
 //! ```
 //! use cubby_connect_server::fn_pipe::{fn_pipe, fn_pipe_factory};
 //! use cubby_connect_server::pipe::{connect, Pipe, PipeFactory};
+//! use cubby_connect_server::pipe;
 //! use std::fmt::Display;
 //!
 //! async fn echo<T>(t: T) -> Result<T, ()> {
@@ -29,6 +30,11 @@
 //! // or
 //!
 //! let e = connect(fn_pipe_factory(echo), fn_pipe(print)).await?;
+//! e.call("Hello, World!").await?;
+//!
+//! // or
+//!
+//! let e = pipe!(echo, print);
 //! e.call("Hello, World!").await?;
 //! # Ok(())
 //! # }

--- a/server/src/fn_pipe.rs
+++ b/server/src/fn_pipe.rs
@@ -1,0 +1,185 @@
+//! Function adapter for `Pipe` and `PipeFactory`
+//!
+//! # Examples
+//!
+//! ```
+//! use cubby_connect_server::fn_pipe::{fn_pipe, fn_pipe_factory};
+//! use cubby_connect_server::pipe::{Pipe, PipeFactory};
+//! use std::fmt::Display;
+//!
+//! async fn echo<T>(t: T) -> Result<T, ()> {
+//!     Ok(t)
+//! }
+//!
+//! async fn print<T: Display>(t: T) -> Result<(), ()> {
+//!     assert_eq!(t.to_string(), "Hello, World!");
+//!     print!("{}", t);
+//!     Ok(())
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), ()> {
+//! let p = fn_pipe(print);
+//! let ef = fn_pipe_factory(echo);
+//! // `e` would be the pipe: `Echo` > `Print`
+//! let e = ef.new_pipe(p).await?;
+//! // this would print "Hello, World" to stdout
+//! e.call("Hello, World!").await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::pipe::{IntoPipe, IntoPipeFactory, Pipe, PipeFactory};
+use futures::future::{ok, LocalBoxFuture, Ready};
+use std::future::Future;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// `Pipe` for closures/functions for simple definition of use.
+/// The type of function would be as: `async fn<T>(T) -> Result<(), Err>`
+pub struct FnPipe<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    f: F,
+    _marker: PhantomData<fn(M)>,
+}
+
+impl<F, M, Fut, Err> FnPipe<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    fn new(f: F) -> Self {
+        Self {
+            f,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// This would simply call the function
+impl<F, M, Fut, Err> Pipe<M> for FnPipe<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    type Error = Err;
+    type Future = Fut;
+
+    fn call(&self, msg: M) -> Self::Future {
+        (self.f)(msg)
+    }
+}
+
+impl<F, M, Fut, Err> IntoPipe<FnPipe<F, M, Fut, Err>, M> for F
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    fn into_pipe(self) -> FnPipe<F, M, Fut, Err> {
+        FnPipe::new(self)
+    }
+}
+
+/// public function wrapper of `FnPipe`
+/// use this to change function into `Pipe`
+pub fn fn_pipe<F, M, Fut, Err>(f: F) -> FnPipe<F, M, Fut, Err>
+where
+    F: Fn(M) -> Fut,
+    Fut: Future<Output = Result<(), Err>>,
+{
+    FnPipe::new(f)
+}
+
+/// `PipeFactory` for closures/functions for simple definition of use.
+/// The type of function would be as: `async fn<T, U>(T) -> Result<U, Err>`
+/// This would be connected to other `Pipe` as: `async fn<U>(U) -> Result<(), Err>`
+/// It would be easier to know the data flow.
+///
+/// The lifetime is same as the closure.
+///
+/// *a little overhead due to lifetime problem*
+/// function should go into `Arc` because it is multi-thread
+pub struct FnPipeFactory<'a, F, M1, M2, Fut, Err>
+where
+    F: Fn(M1) -> Fut + 'a,
+    Fut: Future<Output = Result<M2, Err>>,
+{
+    f: Arc<F>,
+    _marker: PhantomData<&'a fn(M1) -> M2>,
+}
+
+impl<'a, F, M1, M2, Fut, Err> FnPipeFactory<'a, F, M1, M2, Fut, Err>
+where
+    F: Fn(M1) -> Fut + 'a,
+    Fut: Future<Output = Result<M2, Err>>,
+{
+    fn new(f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, F, M1, M2, Fut, Err, P> PipeFactory<M1, P> for FnPipeFactory<'a, F, M1, M2, Fut, Err>
+where
+    F: Fn(M1) -> Fut,
+    Fut: Future<Output = Result<M2, Err>>,
+    P: Pipe<M2, Error = Err> + 'a,
+{
+    type Next = M2;
+    type Error = Err;
+    #[allow(clippy::type_complexity)]
+    type Pipe = FnPipe<
+        Box<dyn Fn(M1) -> LocalBoxFuture<'a, Result<(), Err>> + 'a>,
+        M1,
+        LocalBoxFuture<'a, Result<(), Err>>,
+        Err,
+    >;
+    type InitError = Err;
+    type Future = Ready<Result<Self::Pipe, Err>>;
+
+    fn new_pipe(&self, prev: P) -> Self::Future {
+        // a little overhead due to lifetime problem
+        // -> `prev` is captured in closure but it cannot be borrowed into async
+        //    block because closure's lifetime cannot be set.
+        // this should go into `Arc` because we are running this in multi-thread
+        // TODO: think of a better way (maybe unsafe?)
+        let prev = Arc::new(prev);
+        let f = self.f.clone();
+
+        ok(fn_pipe(Box::new(move |msg| {
+            let prev_ = prev.clone();
+            let f_ = f.clone();
+            Box::pin(async move {
+                prev_.call(f_(msg).await?).await?;
+                Ok(())
+            })
+        })))
+    }
+}
+
+impl<'a, F, M1, M2, Fut, Err, P> IntoPipeFactory<FnPipeFactory<'a, F, M1, M2, Fut, Err>, M1, P>
+    for F
+where
+    F: Fn(M1) -> Fut + 'a,
+    Fut: Future<Output = Result<M2, Err>>,
+    P: Pipe<M2, Error = Err> + 'a,
+{
+    fn into_pipe_factory(self) -> FnPipeFactory<'a, F, M1, M2, Fut, Err> {
+        FnPipeFactory::new(self)
+    }
+}
+
+/// public function wrapper of `FnPipeFactory`
+/// use this to change function to `PipeFactory`
+pub fn fn_pipe_factory<'a, F, M1, M2, Fut, Err>(f: F) -> FnPipeFactory<'a, F, M1, M2, Fut, Err>
+where
+    F: Fn(M1) -> Fut + 'a,
+    Fut: Future<Output = Result<M2, Err>>,
+{
+    FnPipeFactory::new(f)
+}

--- a/server/src/handler.rs
+++ b/server/src/handler.rs
@@ -1,0 +1,88 @@
+//! This is a handler trait to handle asynchronously
+//!
+//! # Examples
+//!
+//! ```
+//! use cubby_connect_server::handler::Handler;
+//! use futures::future::{ok, Ready};
+//! use std::fmt::Display;
+//!
+//! struct Hello;
+//!
+//! impl<S: Display> Handler<S> for Hello {
+//!     type Error = ();
+//!     type Future = Ready<Result<(), ()>>;
+//!
+//!     fn call(&self, msg: S) -> Self::Future {
+//!         println!("Hello {}", msg);
+//!         ok(())
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), ()> {
+//! let handler = Hello;
+//! // this would print "Hello World"
+//! handler.call("World");
+//! # Ok(())
+//! # }
+//! ```
+
+use std::future::Future;
+
+/// This is a pipe to send data easily using future
+pub trait Handler<M> {
+    /// error when processing
+    type Error;
+
+    /// future when building pipe
+    type Future: Future<Output = Result<(), Self::Error>>;
+
+    fn call(&self, msg: M) -> Self::Future;
+}
+
+/// This is a trait that can make into `Pipe`
+pub trait IntoHandler<P, M>
+where
+    P: Handler<M>,
+{
+    fn into_handler(self) -> P;
+}
+
+impl<P, M> IntoHandler<P, M> for P
+where
+    P: Handler<M>,
+{
+    /// `Pipe` can be turn into `Pipe` itself
+    fn into_handler(self) -> P {
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fmt::Display;
+
+    use futures::future::{ok, Ready};
+
+    use super::*;
+
+    struct Check(String);
+
+    impl<S: Display> Handler<S> for Check {
+        type Error = ();
+        type Future = Ready<Result<(), ()>>;
+
+        fn call(&self, msg: S) -> Self::Future {
+            assert_eq!(msg.to_string(), self.0);
+            ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_test() -> Result<(), ()> {
+        let handler = Check("hello".to_string());
+        handler.call("hello").await?;
+        Ok(())
+    }
+}

--- a/server/src/handler.rs
+++ b/server/src/handler.rs
@@ -30,31 +30,31 @@
 
 use std::future::Future;
 
-/// This is a pipe to send data easily using future
-pub trait Handler<M> {
+/// This is a handler to send data easily using future
+pub trait Handler<T> {
     /// error when processing
     type Error;
 
-    /// future when building pipe
+    /// future when building handler
     type Future: Future<Output = Result<(), Self::Error>>;
 
-    fn call(&self, msg: M) -> Self::Future;
+    fn call(&self, msg: T) -> Self::Future;
 }
 
-/// This is a trait that can make into `Pipe`
-pub trait IntoHandler<P, M>
+/// This is a trait that can make into `Handler`
+pub trait IntoHandler<H, T>
 where
-    P: Handler<M>,
+    H: Handler<T>,
 {
-    fn into_handler(self) -> P;
+    fn into_handler(self) -> H;
 }
 
-impl<P, M> IntoHandler<P, M> for P
+impl<H, T> IntoHandler<H, T> for H
 where
-    P: Handler<M>,
+    H: Handler<T>,
 {
-    /// `Pipe` can be turn into `Pipe` itself
-    fn into_handler(self) -> P {
+    /// `Handler` can be turn into `Handler` itself
+    fn into_handler(self) -> H {
         self
     }
 }

--- a/server/src/layer.rs
+++ b/server/src/layer.rs
@@ -32,7 +32,7 @@
 //!     H::Future: 'static,
 //! {
 //!     type Next = T;
-//!     type Error = P::Error;
+//!     type Error = H::Error;
 //!     type Handler = Echo<T, H>;
 //!     type InitError = ();
 //!     type Future = Ready<Result<Self::Handler, Self::InitError>>;

--- a/server/src/layer.rs
+++ b/server/src/layer.rs
@@ -90,7 +90,7 @@
 //! let p = Print;
 //! let ef = EchoFactory;
 //! // `e` would be the pipe: `Echo` > `Print`
-//! let e = ef.new_pipe(p).await?;
+//! let e = ef.new_handler(p).await?;
 //! // this would print "Hello, World!" to stdout
 //! e.call("Hello, World!").await?;
 //! # Ok(())

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -20,7 +20,6 @@ extern crate derive_builder;
 
 pub mod config;
 pub mod pipe;
-pub mod server;
 
 mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/sample.rs"));

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -19,6 +19,7 @@ extern crate derive_builder;
 
 pub mod config;
 pub mod pipe;
+pub mod fn_pipe;
 
 mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/sample.rs"));

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,8 +18,8 @@
 extern crate derive_builder;
 
 pub mod config;
-pub mod pipe;
 pub mod fn_pipe;
+pub mod pipe;
 
 mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/sample.rs"));

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,8 +18,10 @@
 extern crate derive_builder;
 
 pub mod config;
-pub mod fn_pipe;
-pub mod pipe;
+pub mod fn_handler;
+pub mod fn_layer;
+pub mod handler;
+pub mod layer;
 
 mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/sample.rs"));

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -95,7 +95,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
 
 use futures::future::{ok, LocalBoxFuture, Ready};
 use std::future::Future;

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -96,10 +96,7 @@
 //! # }
 //! ```
 
-use futures::future::{ok, LocalBoxFuture, Ready};
 use std::future::Future;
-use std::marker::PhantomData;
-use std::sync::Arc;
 
 /// This is a factory for `Pipe`. Since `Pipe` has chain connection,
 /// it have to hold the previous `Pipe`. It would be provided in factory.
@@ -173,4 +170,15 @@ where
     fn into_pipe_factory(self) -> PF {
         self
     }
+}
+
+/// `PipeFactory` and `Pipe` connect function for simple use.
+pub fn connect<IPF, PF, M, IP, P>(fac: IPF, pipe: IP) -> PF::Future
+where
+    IPF: IntoPipeFactory<PF, M, P>,
+    PF: PipeFactory<M, P>,
+    P: Pipe<PF::Next>,
+    IP: IntoPipe<P, PF::Next>,
+{
+    fac.into_pipe_factory().new_pipe(pipe.into_pipe())
 }

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -182,3 +182,13 @@ where
 {
     fac.into_pipe_factory().new_pipe(pipe.into_pipe())
 }
+
+#[macro_export]
+macro_rules! pipe {
+    ($x:expr, $y:expr) => {
+        connect($x, $y).await?
+    };
+    ($x:expr, $($y:expr),+) => {
+        connect($x, pipe!($( $y ),+)).await?
+    };
+}

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -187,7 +187,7 @@ where
 ///
 /// # Example
 ///
-/// ```no-run
+/// ```no_run
 /// pipe!(some_pipe_factory1, some_pipe_factory2, ..., some_pipe);
 /// ```
 #[macro_export]

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -187,7 +187,7 @@ where
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// pipe!(some_pipe_factory1, some_pipe_factory2, ..., some_pipe);
 /// ```
 #[macro_export]

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -309,6 +309,7 @@ where
 {
     type Next = M2;
     type Error = Err;
+    #[allow(clippy::type_complexity)]
     type Pipe = FnPipe<
         Box<dyn Fn(M1) -> LocalBoxFuture<'a, Result<(), Err>> + 'a>,
         M1,

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -6,12 +6,12 @@
 //! # Examples
 //!
 //! ```
+//! use cubby_connect_server::pipe::{Pipe, PipeFactory};
+//! use futures::future::{ok, LocalBoxFuture, Ready};
 //! use std::fmt::Display;
 //! use std::future::Future;
 //! use std::marker::PhantomData;
 //! use std::task::{Context, Poll};
-//! use futures::future::{ok, Ready, LocalBoxFuture};
-//! use cubby_connect_server::pipe::{Pipe, PipeFactory};
 //!
 //! // Factory of Echo.
 //! pub struct EchoFactory;
@@ -19,7 +19,7 @@
 //! // Pipe that sends the message to next as is
 //! pub struct Echo<T, P>
 //! where
-//!     P: Pipe<T>
+//!     P: Pipe<T>,
 //! {
 //!     prev: P,
 //!     _marker: PhantomData<T>,
@@ -39,7 +39,7 @@
 //!     fn new_pipe(&self, prev: P) -> Self::Future {
 //!         ok(Echo {
 //!             prev,
-//!             _marker: PhantomData::default()
+//!             _marker: PhantomData::default(),
 //!         })
 //!     }
 //! }
@@ -69,7 +69,7 @@
 //!
 //! impl<S> Pipe<S> for Print
 //! where
-//!     S: Display
+//!     S: Display,
 //! {
 //!     type Error = ();
 //!     type Future = Ready<Result<(), Self::Error>>;
@@ -99,8 +99,8 @@
 //! This is same as above:
 //!
 //! ```
-//! use std::fmt::Display;
 //! use cubby_connect_server::pipe::{fn_pipe, fn_pipe_factory, Pipe, PipeFactory};
+//! use std::fmt::Display;
 //!
 //! async fn echo<T>(t: T) -> Result<T, ()> {
 //!     Ok(t)
@@ -123,7 +123,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
 
 use futures::future::{ok, LocalBoxFuture, Ready};
 use std::future::Future;

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -96,33 +96,6 @@
 //! # }
 //! ```
 //!
-//! This is same as above:
-//!
-//! ```
-//! use cubby_connect_server::pipe::{fn_pipe, fn_pipe_factory, Pipe, PipeFactory};
-//! use std::fmt::Display;
-//!
-//! async fn echo<T>(t: T) -> Result<T, ()> {
-//!     Ok(t)
-//! }
-//!
-//! async fn print<T: Display>(t: T) -> Result<(), ()> {
-//!     assert_eq!(t.to_string(), "Hello, World!");
-//!     print!("{}", t);
-//!     Ok(())
-//! }
-//!
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), ()> {
-//! let p = fn_pipe(print);
-//! let ef = fn_pipe_factory(echo);
-//! // `e` would be the pipe: `Echo` > `Print`
-//! let e = ef.new_pipe(p).await?;
-//! // this would print "Hello, World" to stdout
-//! e.call("Hello, World!").await?;
-//! # Ok(())
-//! # }
-//! ```
 
 use futures::future::{ok, LocalBoxFuture, Ready};
 use std::future::Future;
@@ -183,74 +156,6 @@ where
     }
 }
 
-/// `Pipe` for closures/functions for simple definition of use.
-/// The type of function would be as: `async fn<T>(T) -> Result<(), Err>`
-pub struct FnPipe<F, M, Fut, Err>
-where
-    F: Fn(M) -> Fut,
-    Fut: Future<Output = Result<(), Err>>,
-{
-    f: F,
-    _marker: PhantomData<fn(M)>,
-}
-
-impl<F, M, Fut, Err> FnPipe<F, M, Fut, Err>
-where
-    F: Fn(M) -> Fut,
-    Fut: Future<Output = Result<(), Err>>,
-{
-    fn new(f: F) -> Self {
-        Self {
-            f,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<F, M, Fut, Err> Clone for FnPipe<F, M, Fut, Err>
-where
-    F: Fn(M) -> Fut + Clone,
-    Fut: Future<Output = Result<(), Err>>,
-{
-    fn clone(&self) -> Self {
-        Self::new(self.f.clone())
-    }
-}
-
-/// This would simply call the function
-impl<F, M, Fut, Err> Pipe<M> for FnPipe<F, M, Fut, Err>
-where
-    F: Fn(M) -> Fut,
-    Fut: Future<Output = Result<(), Err>>,
-{
-    type Error = Err;
-    type Future = Fut;
-
-    fn call(&self, msg: M) -> Self::Future {
-        (self.f)(msg)
-    }
-}
-
-impl<F, M, Fut, Err> IntoPipe<FnPipe<F, M, Fut, Err>, M> for F
-where
-    F: Fn(M) -> Fut,
-    Fut: Future<Output = Result<(), Err>>,
-{
-    fn into_pipe(self) -> FnPipe<F, M, Fut, Err> {
-        FnPipe::new(self)
-    }
-}
-
-/// public function wrapper of `FnPipe`
-/// use this to change function into `Pipe`
-pub fn fn_pipe<F, M, Fut, Err>(f: F) -> FnPipe<F, M, Fut, Err>
-where
-    F: Fn(M) -> Fut,
-    Fut: Future<Output = Result<(), Err>>,
-{
-    FnPipe::new(f)
-}
-
 /// This trait can make into `PipeFactory`
 pub trait IntoPipeFactory<PF, M, P>
 where
@@ -265,98 +170,8 @@ where
     PF: PipeFactory<M, P>,
     P: Pipe<PF::Next>,
 {
+    /// `PipeFactory` can be turn into `PipeFactory` itself
     fn into_pipe_factory(self) -> PF {
         self
     }
-}
-
-/// `PipeFactory` for closures/functions for simple definition of use.
-/// The type of function would be as: `async fn<T, U>(T) -> Result<U, Err>`
-/// This would be connected to other `Pipe` as: `async fn<U>(U) -> Result<(), Err>`
-/// It would be easier to know the data flow.
-///
-/// The lifetime is same as the closure.
-///
-/// *a little overhead due to lifetime problem*
-/// function should go into `Arc` because it is multi-thread
-pub struct FnPipeFactory<'a, F, M1, M2, Fut, Err>
-where
-    F: Fn(M1) -> Fut + 'a,
-    Fut: Future<Output = Result<M2, Err>>,
-{
-    f: Arc<F>,
-    _marker: PhantomData<&'a fn(M1) -> M2>,
-}
-
-impl<'a, F, M1, M2, Fut, Err> FnPipeFactory<'a, F, M1, M2, Fut, Err>
-where
-    F: Fn(M1) -> Fut + 'a,
-    Fut: Future<Output = Result<M2, Err>>,
-{
-    fn new(f: F) -> Self {
-        Self {
-            f: Arc::new(f),
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<'a, F, M1, M2, Fut, Err, P> PipeFactory<M1, P> for FnPipeFactory<'a, F, M1, M2, Fut, Err>
-where
-    F: Fn(M1) -> Fut,
-    Fut: Future<Output = Result<M2, Err>>,
-    P: Pipe<M2, Error = Err> + 'a,
-{
-    type Next = M2;
-    type Error = Err;
-    #[allow(clippy::type_complexity)]
-    type Pipe = FnPipe<
-        Box<dyn Fn(M1) -> LocalBoxFuture<'a, Result<(), Err>> + 'a>,
-        M1,
-        LocalBoxFuture<'a, Result<(), Err>>,
-        Err,
-    >;
-    type InitError = Err;
-    type Future = Ready<Result<Self::Pipe, Err>>;
-
-    fn new_pipe(&self, prev: P) -> Self::Future {
-        // a little overhead due to lifetime problem
-        // -> `prev` is captured in closure but it cannot be borrowed into async
-        //    block because closure's lifetime cannot be set.
-        // this should go into `Arc` because we are running this in multi-thread
-        // TODO: think of a better way (maybe unsafe?)
-        let prev = Arc::new(prev);
-        let f = self.f.clone();
-
-        ok(fn_pipe(Box::new(move |msg| {
-            let prev_ = prev.clone();
-            let f_ = f.clone();
-            Box::pin(async move {
-                prev_.call(f_(msg).await?).await?;
-                Ok(())
-            })
-        })))
-    }
-}
-
-impl<'a, F, M1, M2, Fut, Err, P> IntoPipeFactory<FnPipeFactory<'a, F, M1, M2, Fut, Err>, M1, P>
-    for F
-where
-    F: Fn(M1) -> Fut + 'a,
-    Fut: Future<Output = Result<M2, Err>>,
-    P: Pipe<M2, Error = Err> + 'a,
-{
-    fn into_pipe_factory(self) -> FnPipeFactory<'a, F, M1, M2, Fut, Err> {
-        FnPipeFactory::new(self)
-    }
-}
-
-/// public function wrapper of `FnPipeFactory`
-/// use this to change function to `PipeFactory`
-pub fn fn_pipe_factory<'a, F, M1, M2, Fut, Err>(f: F) -> FnPipeFactory<'a, F, M1, M2, Fut, Err>
-where
-    F: Fn(M1) -> Fut + 'a,
-    Fut: Future<Output = Result<M2, Err>>,
-{
-    FnPipeFactory::new(f)
 }

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -193,10 +193,10 @@ where
 #[macro_export]
 macro_rules! pipe {
     ($x:expr, $y:expr) => {
-        connect($x, $y).await?
+        $crate::pipe::connect($x, $y).await?
     };
     ($x:expr, $($y:expr),+) => {
-        connect($x, pipe!($( $y ),+)).await?
+        $crate::pipe::connect($x, pipe!($( $y ),+)).await?
     };
 }
 

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -183,6 +183,13 @@ where
     fac.into_pipe_factory().new_pipe(pipe.into_pipe())
 }
 
+/// macro to use pipe more simple
+///
+/// # Example
+///
+/// ```no-run
+/// pipe!(some_pipe_factory1, some_pipe_factory2, ..., some_pipe);
+/// ```
 #[macro_export]
 macro_rules! pipe {
     ($x:expr, $y:expr) => {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,3 +1,0 @@
-pub struct Server;
-
-impl Server {}


### PR DESCRIPTION
now you can make handler & layer from functions

<details><summary>before</summary>
<p>

```rust
// Factory of Echo.
pub struct EchoFactory;

// Pipe that sends the message to next as is
pub struct Echo<T, P>
where
    P: Handler<T>,
{
    prev: P,
    _marker: PhantomData<T>,
}

impl<T, P> Layer<T, P> for EchoFactory
where
    P: Handler<T>,
    P::Future: 'static,
{
    type Next = T;
    type Error = P::Error;
    type Handler = Echo<T, P>;
    type InitError = ();
    type Future = Ready<Result<Self::Handler, Self::InitError>>;

    fn new_handler(&self, prev: P) -> Self::Future {
        ok(Echo {
            prev,
            _marker: PhantomData::default(),
        })
    }
}

impl<T, P> Handler<T> for Echo<T, P>
where
    P: Handler<T>,
    P::Future: 'static,
{
    type Error = P::Error;
    type Future = LocalBoxFuture<'static, Result<(), Self::Error>>;

    fn call(&self, msg: T) -> Self::Future {
        let prev_call = self.prev.call(msg);
        // this would act as same future of previous pipe,
        // but type of `Ok` is `()`
        Box::pin(async move {
            prev_call.await?;
            Ok(())
        })
    }
}

// print to stdout that got
pub struct Print;
impl<S> Handler<S> for Print
where
    S: Display,
{
    type Error = ();
    type Future = Ready<Result<(), Self::Error>>;

    // just calls `print!`
    // then just be ready
    fn call(&self, msg: S) -> Self::Future {
        // This should equal to "Hello, World!" in this example
        assert_eq!(msg.to_string(), "Hello, World!");
        print!("{}", msg);
        ok(())
    }
}

let p = Print;
let ef = EchoFactory;
// `e` would be the pipe: `Echo` > `Print`
let e = ef.new_handler(p).await?;
// this would print "Hello, World!" to stdout
e.call("Hello, World!").await?;
```

</p>
</details>

would be same as:

```rust
async fn echo<T>(t: T) -> Result<T, ()> {
    Ok(t)
}

async fn print<T: Display>(t: T) -> Result<(), ()> {
    print!("{}", t);
    Ok(())
}

// `e` would be the pipe: `echo` > `print`
let e = apply!(echo, print);
// since echo just pass the message, below is possible
let e = apply!(echo, echo, echo, print);
// this would print "Hello, World" to stdout
e.call("Hello, World!").await?;

```